### PR TITLE
Setup osx script

### DIFF
--- a/macrobot/ansible-playbook-install-android.yml
+++ b/macrobot/ansible-playbook-install-android.yml
@@ -1,0 +1,6 @@
+---
+
+- hosts: all
+
+  tasks:  
+  - include: ansible-task-install-android.yml

--- a/macrobot/ansible-task-install-android.yml
+++ b/macrobot/ansible-task-install-android.yml
@@ -1,0 +1,24 @@
+---
+
+   - name: Get current username
+     shell: echo `whoami`
+     register: ansible_username     
+
+   - debug: 
+        msg: "{{ ansible_username.stdout }}"
+
+   - name: Install Android SDK, Java through cask
+     homebrew_cask: 
+        name: "{{ item }}"
+        state: present
+     with_items:
+       - java8
+       - android-sdk
+     ignore_errors: true
+
+   - name: Install System Image for creating Android AVD of v25
+     shell: sdkmanager 'system-images;android-25;google_apis;x86'
+  
+   - name: Create AVD of version 25 
+     shell: echo no | avdmanager create avd -n testAVD25 -k "system-images;android-25;google_apis;x86" -g "google_apis"
+     

--- a/macrobot/ansible-task-install-android.yml
+++ b/macrobot/ansible-task-install-android.yml
@@ -20,5 +20,20 @@
      shell: sdkmanager 'system-images;android-25;google_apis;x86'
   
    - name: Create AVD of version 25 
-     shell: echo no | avdmanager create avd -n testAVD25 -k "system-images;android-25;google_apis;x86" -g "google_apis"
-     
+     shell: echo no | avdmanager create avd -n testAVD25 -k "system-images;android-25;google_apis;x86" -g "google_apis" --force
+
+   - name: Set Environment Variable for ANDROID_SDK_ROOT
+     lineinfile: 
+        path: ~/.bash_profile
+        insertafter: EOF
+        line: "{{ item.path }}"
+        state: present
+     with_items:
+       - { path: 'export ANDROID_SDK_ROOT=/usr/local/share/android-sdk' }
+       - { path: 'export ANDROID_HOME=/usr/local/share/android-sdk' }
+       - { path: 'export ANDROID_SDK_HOME=/usr/local/share/android-sdk' }
+       - { path: 'PATH=$ANDROID_HOME/platform-tools:$PATH' }
+       - { path: 'PATH=$ANDROID_HOME/tools:$PATH' }
+
+   - name: Set Environment Variable for PATH for emulator
+     shell: echo "export PATH=/usr/local/share/android-sdk/platform-tools:$PATH" >> ~/.bash_profile

--- a/macrobot/ansible-task-install-robot-framework.yml
+++ b/macrobot/ansible-task-install-robot-framework.yml
@@ -116,6 +116,12 @@
      with_fileglob:
        - /tmp/geckodriver*
 
+   - name: Launch Firefox to start pref file
+     shell: open -a Firefox 'http://www.google.com/'
+    
+   - name: Close Firefox after start pref file
+     shell: pkill -f firefox
+
    - name: List firefox default profile folder (Firefox Config) 
      command: ls -v "~/Library/Application Support/Firefox/Profiles/"
      register: firefox_default_profile


### PR DESCRIPTION
1) added firefox open and close trigger to create user prefs file

2) android env installed - with env variables inserted via ansible script
- installation of android-sdk via homebrew cask - paths are always symlined automatically by cask hence path will always work

Android playbook is kept a separate playbook 